### PR TITLE
Fixing coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
     - docker build -t memaldi/de-rq docker/rq/
     - cd docker
     - docker-compose up -d
+    - cd ..
 
 after_success:
   coveralls


### PR DESCRIPTION
When configuring travis-ci to build docker images, coveralls broke.